### PR TITLE
Assume tag is lost if ADPU command does not respond with an ADPU response

### DIFF
--- a/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/reader/MinovaCommands.java
+++ b/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/reader/MinovaCommands.java
@@ -79,8 +79,8 @@ public class MinovaCommands {
                 .build();
 
         String response = reader.outputInput(minovaCommand);
-        if (response.endsWith(",NAK")) {
-            throw new McrReaderException("Minova reader responded with NAK.");
+        if (!response.startsWith("RAPDU=") || response.endsWith(",NAK")) {
+            throw new McrReaderException("Minova reader responded with '" + response + "'");
         }
 
         return ByteArrayHexStringConverter.hexStringToByteArray(response.substring(response.indexOf("=") + 1));

--- a/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/reader/MinovaCommands.java
+++ b/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/reader/MinovaCommands.java
@@ -79,7 +79,8 @@ public class MinovaCommands {
                 .build();
 
         String response = reader.outputInput(minovaCommand);
-        if (!response.startsWith("RAPDU=") || response.endsWith(",NAK")) {
+
+        if (!response.startsWith(reader.getReaderId()+",RAPDU=") || response.endsWith(",NAK")) {
             throw new McrReaderException("Minova reader responded with '" + response + "'");
         }
 

--- a/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/reader/MinovaIsoDepWrapper.java
+++ b/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/reader/MinovaIsoDepWrapper.java
@@ -1,5 +1,10 @@
 package no.entur.android.nfc.external.minova.reader;
 
+import android.content.Context;
+import android.content.Intent;
+
+import no.entur.android.nfc.external.ExternalNfcTagCallback;
+import no.entur.android.nfc.external.minova.service.MinovaService;
 import no.entur.android.nfc.external.service.tag.TagProxy;
 import no.entur.android.nfc.external.tag.AbstractReaderIsoDepWrapper;
 import no.entur.android.nfc.tcpserver.CommandInputOutputThread;
@@ -8,10 +13,12 @@ import no.entur.android.nfc.util.ByteArrayHexStringConverter;
 public class MinovaIsoDepWrapper extends AbstractReaderIsoDepWrapper {
 
     private final MinovaCommands commands;
+    private final Context context;
 
-    public MinovaIsoDepWrapper(CommandInputOutputThread<String, String> reader) {
+    public MinovaIsoDepWrapper(CommandInputOutputThread<String, String> reader, Context context) {
         super(-1);
         this.commands = new MinovaCommands(reader);
+        this.context = context;
     }
 
     @Override
@@ -21,6 +28,8 @@ public class MinovaIsoDepWrapper extends AbstractReaderIsoDepWrapper {
         } catch(McrReaderException e) {
             // there is no "tag lost" even, so make sure to loose the tag as soon as possible if some command does not respond
             tagProxy.close();
+
+            sendTagLeftFieldBroadcast();
 
             throw e;
         }
@@ -34,7 +43,18 @@ public class MinovaIsoDepWrapper extends AbstractReaderIsoDepWrapper {
             // there is no "tag lost" even, so make sure to loose the tag as soon as possible if some command does not respond
             tagProxy.close();
 
+            sendTagLeftFieldBroadcast();
+
             throw e;
         }
     }
+
+    private void sendTagLeftFieldBroadcast() {
+        Intent intent = new Intent();
+        intent.setAction(ExternalNfcTagCallback.ACTION_TAG_LEFT_FIELD);
+        intent.putExtra(MinovaService.EXTRA_TAG_LEFT_FIELD_REASON, MinovaService.EXTRA_TAG_LEFT_FIELD_REASON_NEW_TAG);
+
+        context.sendBroadcast(intent, "android.permission.NFC");
+    }
+
 }

--- a/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/reader/MinovaIsoDepWrapper.java
+++ b/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/reader/MinovaIsoDepWrapper.java
@@ -53,6 +53,7 @@ public class MinovaIsoDepWrapper extends AbstractReaderIsoDepWrapper {
         Intent intent = new Intent();
         intent.setAction(ExternalNfcTagCallback.ACTION_TAG_LEFT_FIELD);
         intent.putExtra(MinovaService.EXTRA_TAG_LEFT_FIELD_REASON, MinovaService.EXTRA_TAG_LEFT_FIELD_REASON_NEW_TAG);
+        intent.putExtra(MinovaService.EXTRA_TAG_LEFT_FIELD_SERVICE_HANDLE, tagProxy.getHandle());
 
         context.sendBroadcast(intent, "android.permission.NFC");
     }

--- a/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/reader/MinovaIsoDepWrapper.java
+++ b/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/reader/MinovaIsoDepWrapper.java
@@ -1,5 +1,6 @@
 package no.entur.android.nfc.external.minova.reader;
 
+import no.entur.android.nfc.external.service.tag.TagProxy;
 import no.entur.android.nfc.external.tag.AbstractReaderIsoDepWrapper;
 import no.entur.android.nfc.tcpserver.CommandInputOutputThread;
 import no.entur.android.nfc.util.ByteArrayHexStringConverter;
@@ -15,11 +16,25 @@ public class MinovaIsoDepWrapper extends AbstractReaderIsoDepWrapper {
 
     @Override
     public byte[] transceive(byte[] data) throws Exception {
-        return commands.sendAdpu(data);
+        try {
+            return commands.sendAdpu(data);
+        } catch(McrReaderException e) {
+            // there is no "tag lost" even, so make sure to loose the tag as soon as possible if some command does not respond
+            tagProxy.close();
+
+            throw e;
+        }
     }
 
     @Override
     public byte[] transceiveRaw(byte[] data) throws Exception {
-        return commands.sendAdpu(data);
+        try {
+            return commands.sendAdpu(data);
+        } catch(McrReaderException e) {
+            // there is no "tag lost" even, so make sure to loose the tag as soon as possible if some command does not respond
+            tagProxy.close();
+
+            throw e;
+        }
     }
 }

--- a/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/service/MinovaService.java
+++ b/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/service/MinovaService.java
@@ -20,6 +20,8 @@ public class MinovaService extends AbstractMinovaTcpService {
     public static final String EXTRA_TAG_LEFT_FIELD_REASON_NEW_TAG = "NEW_TAG";
     public static final String EXTRA_TAG_LEFT_FIELD_REASON_TRANSCEIVE_FAILED = "TRANSCEIVE_FAILED";
 
+    public static final String EXTRA_TAG_LEFT_FIELD_SERVICE_HANDLE = AbstractMinovaTcpService.class.getName() + ".extra.EXTRA_TAG_LEFT_FIELD_SERVICE_HANDLE";
+
     protected IsoDepTagServiceSupport isoDepTagServiceSupport;
 
     public MinovaService(int port, int readers) {
@@ -46,6 +48,7 @@ public class MinovaService extends AbstractMinovaTcpService {
             Intent intent = new Intent();
             intent.setAction(ExternalNfcTagCallback.ACTION_TAG_LEFT_FIELD);
             intent.putExtra(EXTRA_TAG_LEFT_FIELD_REASON, EXTRA_TAG_LEFT_FIELD_REASON_NEW_TAG);
+            intent.putExtra(EXTRA_TAG_LEFT_FIELD_SERVICE_HANDLE, currentTagProxy.getHandle());
 
             sendBroadcast(intent, "android.permission.NFC");
 

--- a/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/service/MinovaService.java
+++ b/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/service/MinovaService.java
@@ -7,6 +7,7 @@ import org.nfctools.api.TagType;
 import no.entur.android.nfc.external.minova.reader.MinovaCommandInputOutputThread;
 import no.entur.android.nfc.external.minova.reader.MinovaIsoDepWrapper;
 import no.entur.android.nfc.external.service.tag.TagProxy;
+import no.entur.android.nfc.external.service.tag.TagTechnology;
 import no.entur.android.nfc.external.tag.IsoDepTagServiceSupport;
 import no.entur.android.nfc.tcpserver.CommandInputOutputThread;
 
@@ -34,6 +35,8 @@ public class MinovaService extends AbstractMinovaTcpService {
         TagProxy currentTagProxy = minovaCommandInputOutputThread.getCurrentTagProxy();
         if(currentTagProxy != null) {
             store.remove(currentTagProxy);
+
+            minovaCommandInputOutputThread.setCurrentTagProxy(null);
         }
 
         if (tag.getTagType() == TagType.DESFIRE_EV1 || tag.getTagType() == TagType.ISO_DEP) {

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/service/tag/TagProxy.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/service/tag/TagProxy.java
@@ -1,13 +1,8 @@
 package no.entur.android.nfc.external.service.tag;
 
-import android.nfc.NdefMessage;
-import android.nfc.NdefRecord;
-
 import java.util.List;
 
 import no.entur.android.nfc.wrapper.TagImpl;
-import no.entur.android.nfc.wrapper.tech.Ndef;
-import no.entur.android.nfc.wrapper.tech.NdefFormatable;
 
 public class TagProxy {
 
@@ -18,12 +13,15 @@ public class TagProxy {
 
 	private TagTechnology current;
 
+	private TagProxyStore tagProxyStore;
+
 	private boolean present = true;
 
-	public TagProxy(int handle, int slotNumber, List<TagTechnology> technologies) {
+	public TagProxy(int handle, int slotNumber, List<TagTechnology> technologies, TagProxyStore tagProxyStore) {
 		this.handle = handle;
 		this.slotNumber = slotNumber;
 		this.technologies = technologies;
+		this.tagProxyStore = tagProxyStore;
 	}
 
 	public TagTechnology getCurrent() {
@@ -116,5 +114,9 @@ public class TagProxy {
 			}
 		}
 		return false;
+	}
+
+	public void close() {
+		tagProxyStore.remove(this);
 	}
 }

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/service/tag/TagProxyStore.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/service/tag/TagProxyStore.java
@@ -30,7 +30,7 @@ public class TagProxyStore {
 	public TagProxy add(int slotNumber, List<TagTechnology> technologies) {
 		int next = nextServiceHandle();
 
-		TagProxy tagProxy = new TagProxy(next, slotNumber, technologies);
+		TagProxy tagProxy = new TagProxy(next, slotNumber, technologies, this);
 
 		add(tagProxy);
 
@@ -45,6 +45,7 @@ public class TagProxyStore {
 
 	public boolean remove(TagProxy proxy) {
 		proxy.setPresent(false);
+		proxy.closeTechnology();
 		synchronized (items) {
 			return items.remove(proxy);
 		}
@@ -55,6 +56,7 @@ public class TagProxyStore {
 			for (TagProxy tagItem : items) {
 				if (tagItem.getSlotNumber() == slotNumber) {
 					tagItem.setPresent(false);
+					tagItem.closeTechnology();
 
 					items.remove(tagItem);
 

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/tag/AbstractReaderIsoDepWrapper.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/tag/AbstractReaderIsoDepWrapper.java
@@ -1,13 +1,20 @@
 package no.entur.android.nfc.external.tag;
 
+import no.entur.android.nfc.external.service.tag.TagProxy;
+
 public abstract class AbstractReaderIsoDepWrapper {
 
 	private static final String TAG = AbstractReaderIsoDepWrapper.class.getName();
 
 	protected int slotNum;
+	protected TagProxy tagProxy;
 
 	public AbstractReaderIsoDepWrapper(int slotNum) {
 		this.slotNum = slotNum;
+	}
+
+	public void setTagProxy(TagProxy tagProxy) {
+		this.tagProxy = tagProxy;
 	}
 
 	// this might also work for raw data

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/tag/IsoDepTagServiceSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/tag/IsoDepTagServiceSupport.java
@@ -58,6 +58,8 @@ public class IsoDepTagServiceSupport extends AbstractTagServiceSupport {
 
             Intent intent = isoDepTagFactory.getTag(tagProxy.getHandle(), null, uid, false, historicalBytes, tagService, extras);
 
+            wrapper.setTagProxy(tagProxy);
+
             LOGGER.debug("Broadcast IsoDep tag");
 
             context.sendBroadcast(intent, ANDROID_PERMISSION_NFC);


### PR DESCRIPTION
The current "tag lost" only happens when a new tag is discovered. 

 * if no ADPU response is returned by the reader, assume tag lost
 * emit tag lost broadcasts
 * set extra flag which make further communications impossible (which should already be blocked via removal from the TagProxy)
