### PR TITLE
Turn off NTAG by default, adjust ultralight adapter

### DIFF
--- a/examples/nfc-reader-app/src/main/java/no/entur/abt/nfc/example/MainActivity.java
+++ b/examples/nfc-reader-app/src/main/java/no/entur/abt/nfc/example/MainActivity.java
@@ -16,6 +16,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
+import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -416,6 +417,18 @@ public class MainActivity extends AppCompatActivity implements ExternalNfcTagCal
                     for (int i = 0; i < length; i += 4) {
                         bout.write(mifareUltralight.readPages(i));
                     }
+
+
+                    // XXX for write testing
+                    boolean write = false;
+                    if(write) {
+                        Random random = new Random();
+                        byte[] payload = new byte[4];
+                        random.nextBytes(payload);
+                        mifareUltralight.writePage(length - 1, payload);
+                        LOGGER.info("Wrote " + ByteArrayHexStringConverter.toHexString(payload));
+                    }
+
                     mifareUltralight.close();
                 }
 

--- a/examples/nfc-reader-app/src/main/java/no/entur/abt/nfc/example/MainActivity.java
+++ b/examples/nfc-reader-app/src/main/java/no/entur/abt/nfc/example/MainActivity.java
@@ -418,17 +418,6 @@ public class MainActivity extends AppCompatActivity implements ExternalNfcTagCal
                         bout.write(mifareUltralight.readPages(i));
                     }
 
-
-                    // XXX for write testing
-                    boolean write = false;
-                    if(write) {
-                        Random random = new Random();
-                        byte[] payload = new byte[4];
-                        random.nextBytes(payload);
-                        mifareUltralight.writePage(length - 1, payload);
-                        LOGGER.info("Wrote " + ByteArrayHexStringConverter.toHexString(payload));
-                    }
-
                     mifareUltralight.close();
                 }
 

--- a/examples/nfc-reader-app/src/main/java/no/entur/abt/nfc/example/MainActivity.java
+++ b/examples/nfc-reader-app/src/main/java/no/entur/abt/nfc/example/MainActivity.java
@@ -10,9 +10,12 @@ import android.widget.ToggleButton;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import org.nfctools.mf.ul.ntag.NfcNtag;
+import org.nfctools.mf.ul.ntag.NfcNtagVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -28,6 +31,8 @@ import no.entur.android.nfc.external.ExternalNfcTagLostCallbackSupport;
 import no.entur.android.nfc.external.acs.reader.AcrReader;
 import no.entur.android.nfc.util.ByteArrayHexStringConverter;
 import no.entur.android.nfc.wrapper.Tag;
+import no.entur.android.nfc.wrapper.tech.MifareUltralight;
+import no.entur.android.nfc.wrapper.tech.NfcA;
 
 public class MainActivity extends AppCompatActivity implements ExternalNfcTagCallback, ExternalNfcReaderCallback, ExternalNfcServiceCallback, ExternalNfcTagLostCallback {
 
@@ -156,6 +161,7 @@ public class MainActivity extends AppCompatActivity implements ExternalNfcTagCal
 
             setTagDetails(tag);
             setIntentDetails(intent);
+            setContents(tag, intent);
         });
     }
 
@@ -167,6 +173,7 @@ public class MainActivity extends AppCompatActivity implements ExternalNfcTagCal
 
             setTagDetails(tag);
             setIntentDetails(intent);
+            setContents(tag, intent);
         });
     }
 
@@ -301,6 +308,132 @@ public class MainActivity extends AppCompatActivity implements ExternalNfcTagCal
         }
     }
 
+    private void setContents(Tag tag, Intent intent) {
+
+        if(isTechType(tag, android.nfc.tech.MifareUltralight.class.getName())) {
+            ByteArrayOutputStream bout = new ByteArrayOutputStream();
+            try {
+                if(intent.hasExtra(NfcNtag.EXTRA_ULTRALIGHT_TYPE)) {
+                    // handle NTAG21x types
+                    // the NTAG21x product familiy have replacements for all previous Ultralight tags
+                    int type = intent.getIntExtra(NfcNtag.EXTRA_ULTRALIGHT_TYPE, 0);
+
+                    NfcA nfcA = NfcA.get(tag);
+                    if(nfcA == null) {
+                        throw new IllegalArgumentException("No NTAG");
+                    }
+
+                    int size;
+                    switch(type) {
+                        case NfcNtagVersion.TYPE_NTAG210: {
+                            size = 48;
+                            break;
+                        }
+                        case NfcNtagVersion.TYPE_NTAG212: {
+                            size = 128;
+                            break;
+                        }
+                        case NfcNtagVersion.TYPE_NTAG213: {
+                            size = 144;
+                            break;
+                        }
+                        case NfcNtagVersion.TYPE_NTAG215: {
+                            size = 504;
+                            break;
+                        }
+                        case NfcNtagVersion.TYPE_NTAG216 :
+                        case NfcNtagVersion.TYPE_NTAG216F : {
+                            size = 888;
+                            break;
+                        }
+                        default : {
+                            size = 48;
+                        }
+                    }
+                    int pagesToRead = size / 4 + 4;
+
+                    // instead of reading 4 and 4 pages, read more using the FAST READ command
+                    int pagesPerRead;
+                    if(nfcA.getMaxTransceiveLength() > 0) {
+                        pagesPerRead = Math.min(255, nfcA.getMaxTransceiveLength() / 4);
+                    } else {
+                        pagesPerRead = 255;
+                    }
+
+                    int reads = pagesToRead / pagesPerRead;
+
+                    if(pagesToRead % pagesPerRead != 0) {
+                        reads++;
+                    }
+
+                    try {
+                        nfcA.connect();
+                        int read = 0;
+                        for (int i = 0; i < reads; i++) {
+                            int range = Math.min(pagesPerRead, pagesToRead - read);
+
+                            byte[] fastRead = new byte[]{
+                                    0x3A,
+                                    (byte) (read & 0xFF), // start page
+                                    (byte) ((read + range - 1) & 0xFF), // end page (inclusive)
+                            };
+
+                            bout.write(nfcA.transceive(fastRead));
+
+                            read += range;
+                        }
+                    } finally {
+                        nfcA.close();
+                    }
+
+
+                } else {
+                    MifareUltralight mifareUltralight = MifareUltralight.get(tag);
+                    if(mifareUltralight == null) {
+                        throw new IllegalArgumentException("No Mifare Ultralight");
+                    }
+                    mifareUltralight.connect();
+
+                    int length;
+
+                    int type = mifareUltralight.getType();
+                    switch (type) {
+                        case MifareUltralight.TYPE_ULTRALIGHT: {
+                            length = 12;
+
+                            break;
+                        }
+                        case MifareUltralight.TYPE_ULTRALIGHT_C: {
+                            length = 36;
+
+                            break;
+                        }
+                        default:
+                            throw new IllegalArgumentException("Unknown mifare ultralight tag " + type);
+                    }
+
+                    // android read 4 and 4 pages of 4 bytes
+                    for (int i = 0; i < length; i += 4) {
+                        bout.write(mifareUltralight.readPages(i));
+                    }
+                    mifareUltralight.close();
+                }
+
+                byte[] buffer = bout.toByteArray();
+
+                StringBuilder builder = new StringBuilder();
+                for(int k = 0; k < buffer.length; k+= 4) {
+                    builder.append( String.format("%02x", (k / 4)) + " " + ByteArrayHexStringConverter.toHexString(buffer, k, 4));
+                    builder.append('\n');
+                }
+
+                LOGGER.info(builder.toString());
+            } catch(Exception e) {
+                LOGGER.warn("Problem processing tag technology", e);
+            }
+        }
+    }
+
     public void setTagDetailTechTypes(Tag tag) {
         StringBuilder builder = new StringBuilder();
 
@@ -315,6 +448,17 @@ public class MainActivity extends AppCompatActivity implements ExternalNfcTagCal
         }
 
         setTextViewText(R.id.tagDetailTechTypes, builder);
+    }
+
+    private boolean isTechType(Tag tag, String type) {
+        String[] techList = tag.getTechList();
+        for (String t : techList) {
+            if(t.equals(type)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public void setTextViewText(final int resource, final int string) {

--- a/examples/nfc-reader-app/src/main/java/no/entur/abt/nfc/example/MainActivity.java
+++ b/examples/nfc-reader-app/src/main/java/no/entur/abt/nfc/example/MainActivity.java
@@ -313,7 +313,7 @@ public class MainActivity extends AppCompatActivity implements ExternalNfcTagCal
         if(isTechType(tag, android.nfc.tech.MifareUltralight.class.getName())) {
             ByteArrayOutputStream bout = new ByteArrayOutputStream();
             try {
-                if(intent.hasExtra(NfcNtag.EXTRA_ULTRALIGHT_TYPE)) {
+                if(intent != null && intent.hasExtra(NfcNtag.EXTRA_ULTRALIGHT_TYPE)) {
                     // handle NTAG21x types
                     // the NTAG21x product familiy have replacements for all previous Ultralight tags
                     int type = intent.getIntExtra(NfcNtag.EXTRA_ULTRALIGHT_TYPE, 0);

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/service/AcsUsbService.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/service/AcsUsbService.java
@@ -1,10 +1,13 @@
 package no.entur.android.nfc.external.acs.service;
 
+import android.content.Intent;
+
 import org.nfctools.api.TagType;
 import org.nfctools.spi.acs.AcsTag;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import no.entur.android.nfc.external.ExternalNfcReaderCallback;
 import no.entur.android.nfc.external.acs.reader.command.ACSIsoDepWrapper;
 import no.entur.android.nfc.external.acs.tag.MifareUltralightTagServiceSupport;
 import no.entur.android.nfc.external.acs.tag.TagUtility;
@@ -15,19 +18,33 @@ import no.entur.android.nfc.util.ByteArrayHexStringConverter;
 
 public class AcsUsbService extends AbstractAcsUsbService {
 
+	/**
+	 *
+	 * Pass this extra to indicate that all mifare ultralight tags are of the NTAG family.
+	 *
+	 */
+	public static final String EXTRA_NTAG_21X_ULTRALIGHTS = ExternalNfcReaderCallback.class.getName() + ".extra.NTAG_21X_ULTRALIGHTS";
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(AcsUsbService.class);
 
 	protected IsoDepTagServiceSupport isoDepTagServiceSupport;
 	protected MifareUltralightTagServiceSupport mifareUltralightTagServiceSupport;
-
-	protected boolean ntag21xUltralights = true;
 
 	@Override
 	public void onCreate() {
 		super.onCreate();
 
 		this.isoDepTagServiceSupport = new IsoDepTagServiceSupport(this, binder, store);
-		this.mifareUltralightTagServiceSupport = new MifareUltralightTagServiceSupport(this, binder, store, ntag21xUltralights);
+		this.mifareUltralightTagServiceSupport = new MifareUltralightTagServiceSupport(this, binder, store, false);
+	}
+
+	@Override
+	public int onStartCommand(Intent intent, int flags, int startId) {
+		boolean ntags = intent.getBooleanExtra(EXTRA_NTAG_21X_ULTRALIGHTS, false);
+
+		mifareUltralightTagServiceSupport.setNtag21xUltralights(ntags);
+
+		return super.onStartCommand(intent, flags, startId);
 	}
 
 	@Override

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/AbstractMifareUltralightTagServiceSupport.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/AbstractMifareUltralightTagServiceSupport.java
@@ -34,10 +34,14 @@ public abstract class AbstractMifareUltralightTagServiceSupport extends Abstract
 
     private static final String TAG = AbstractMifareUltralightTagServiceSupport.class.getName();
 
-    protected final boolean ntag21xUltralights;
+    protected boolean ntag21xUltralights;
 
     public AbstractMifareUltralightTagServiceSupport(Context context, INfcTag tagService, TagProxyStore store, boolean ntag21xUltralights) {
         super(context, tagService, store);
+        this.ntag21xUltralights = ntag21xUltralights;
+    }
+
+    public void setNtag21xUltralights(boolean ntag21xUltralights) {
         this.ntag21xUltralights = ntag21xUltralights;
     }
 

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/MifareUltralightAdapter.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/MifareUltralightAdapter.java
@@ -68,13 +68,13 @@ public class MifareUltralightAdapter extends DefaultTechnology implements Comman
 			int pageOffset = data[1] & 0xFF;
 
 			try {
-				if (data.length != 5) {
-					LOGGER.debug("Problem writing block " + pageOffset + " - size too big: " + (data.length - 1));
+				if (data.length != 6) {
+					LOGGER.debug("Problem writing block " + pageOffset + " - size too big: " + (data.length - 2));
 
 					return new TransceiveResult(TransceiveResult.RESULT_FAILURE, null);
 				}
-				byte[] page = new byte[data.length - 1];
-				System.arraycopy(data, 0, page, 0, page.length);
+				byte[] page = new byte[data.length - 2];
+				System.arraycopy(data, 2, page, 0, page.length);
 
 				readerWriter.writeBlock(pageOffset, new DataBlock(page));
 

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/MifareUltralightAdapter.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/MifareUltralightAdapter.java
@@ -37,9 +37,7 @@ public class MifareUltralightAdapter extends DefaultTechnology implements Comman
 
 	public TransceiveResult transceive(byte[] data, boolean raw) throws RemoteException {
 		// LOGGER.debug("transceive");
-		if (raw) {
-			return getRawTransceiveResult(data);
-		}
+
 		int command = data[0] & 0xFF;
 		if (command == 0x30) {
 			int pageOffset = data[1] & 0xFF;

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/MifareUltralightTagFactory.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/MifareUltralightTagFactory.java
@@ -4,6 +4,8 @@ import android.content.Intent;
 import android.nfc.NfcAdapter;
 import android.os.Bundle;
 
+import org.nfctools.mf.ul.ntag.NfcNtag;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -118,6 +120,9 @@ public class MifareUltralightTagFactory extends TagFactory {
 		addTechBundles(type, id, atr, bundles, tech);
 
 		final Intent intent = getIntent(bundles, tech);
+		if (ntagType != null && ntagType > 0) {
+			intent.putExtra(NfcNtag.EXTRA_ULTRALIGHT_TYPE, ntagType);
+		}
 
 		int[] techArray = new int[tech.size()];
 		for (int i = 0; i < techArray.length; i++) {

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/MifareUltralightTagServiceSupport.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/MifareUltralightTagServiceSupport.java
@@ -65,14 +65,18 @@ public class MifareUltralightTagServiceSupport extends AbstractMifareUltralightT
                         NfcNtagVersion ntagVersion = new NfcNtagVersion(ntag.getVersion());
                         version = ntagVersion.getType();
 
-                        // LOGGER.debug("Detected version " + version);
+                        LOGGER.debug("Detected version " + version);
                     } catch (MfException e) {
-                        LOGGER.debug("No version for Ultralight tag - non NTAG 21x-tag?");
+                        LOGGER.debug("No version for Ultralight tag - non NTAG 21x-tag?", e);
 
                         broadcast(ExternalNfcTagCallback.ACTION_TECH_DISCOVERED);
                         return null;
                     }
+                } else {
+                    LOGGER.debug("Do not detect ntag version for this reader " + readerName);
                 }
+            } else {
+                LOGGER.debug("Do not detect ntag version");
             }
 
             MfBlock[] capabilityBlock = null;

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/MifareUltralightTagServiceSupport.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/MifareUltralightTagServiceSupport.java
@@ -75,8 +75,6 @@ public class MifareUltralightTagServiceSupport extends AbstractMifareUltralightT
                 } else {
                     LOGGER.debug("Do not detect ntag version for this reader " + readerName);
                 }
-            } else {
-                LOGGER.debug("Do not detect ntag version");
             }
 
             MfBlock[] capabilityBlock = null;

--- a/nfc/external-acs/src/main/java/org/nfctools/mf/ul/ntag/NfcNtag.java
+++ b/nfc/external-acs/src/main/java/org/nfctools/mf/ul/ntag/NfcNtag.java
@@ -35,6 +35,7 @@ import no.entur.android.nfc.ResponseAPDU;
 
 public class NfcNtag {
 
+	public static final String EXTRA_ULTRALIGHT_TYPE = NfcNtag.class.getName() + ".extra.ULTRALIGHT_TYPE";
 	private static final String TAG = NfcNtag.class.getName();
 
 	private ACSIsoDepWrapper reader;
@@ -204,15 +205,14 @@ public class NfcNtag {
 		// 0xD4 magic byte
 		// 0x42 InCommunicateThru from PN532
 
+		// see https://stackoverflow.com/questions/44237726/how-to-authenticate-ntag213-with-acr122u
+
 		CommandAPDU command = new CommandAPDU(0xFF, 0x00, 0x00, 0x00, sub, 0, sub.length);
 
 		byte[] responseBytes = reader.transceive(command.getBytes());
 
 		ResponseAPDU response = new ResponseAPDU(responseBytes);
 
-		NfcNtagVersion version = null;
-
-		MfUlReaderWriter readerWriter;
 		if (!response.isSuccess()) {
 			throw new MfException("Unable to issue command " + ByteArrayHexStringConverter.toHexString(sub) + ", response "
 					+ ByteArrayHexStringConverter.toHexString(responseBytes));


### PR DESCRIPTION
Works reading Mifare Ultralight. NTAG support is spotty, depends on the reader.

Example app reads all the ultralight sectors and print them to the log.

```

// XXX for write testing
boolean write = false;
if(write) {
    Random random = new Random();
    byte[] payload = new byte[4];
    random.nextBytes(payload);
    mifareUltralight.writePage(length - 1, payload);
    LOGGER.info("Wrote " + ByteArrayHexStringConverter.toHexString(payload));
}

```