### PR TITLE
Replace Activity with Context for CallbackSupport

### DIFF
--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcReaderCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcReaderCallbackSupport.java
@@ -1,19 +1,14 @@
 package no.entur.android.nfc.external;
 
-import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.nfc.NfcAdapter;
-import android.util.Log;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Executor;
-
-import no.entur.android.nfc.wrapper.Tag;
 
 public class ExternalNfcReaderCallbackSupport {
 
@@ -22,7 +17,7 @@ public class ExternalNfcReaderCallbackSupport {
 	public static final String ANDROID_PERMISSION_NFC = "android.permission.NFC";
 
 	protected final ExternalNfcReaderCallback callback;
-	protected final Activity activity;
+	protected final Context context;
 	protected Executor executor; // non-final for testing
 
 	private boolean recieveReaderBroadcasts = false;
@@ -62,9 +57,9 @@ public class ExternalNfcReaderCallbackSupport {
 
 	};
 
-	public ExternalNfcReaderCallbackSupport(ExternalNfcReaderCallback callback, Activity activity, Executor executor) {
+	public ExternalNfcReaderCallbackSupport(ExternalNfcReaderCallback callback, Context context, Executor executor) {
 		this.callback = callback;
-		this.activity = activity;
+		this.context = context;
 		this.executor = executor;
 	}
 
@@ -105,7 +100,7 @@ public class ExternalNfcReaderCallbackSupport {
 	protected void broadcast(String action) {
 		Intent intent = new Intent();
 		intent.setAction(action);
-		activity.sendBroadcast(intent, ANDROID_PERMISSION_NFC);
+		context.sendBroadcast(intent, ANDROID_PERMISSION_NFC);
 	}
 
 	private void startReceivingReaderBroadcasts() {
@@ -119,7 +114,7 @@ public class ExternalNfcReaderCallbackSupport {
 			filter.addAction(ExternalNfcReaderCallback.ACTION_READER_OPENED);
 			filter.addAction(ExternalNfcReaderCallback.ACTION_READER_CLOSED);
 
-			activity.registerReceiver(readerReceiver, filter, ANDROID_PERMISSION_NFC, null);
+			context.registerReceiver(readerReceiver, filter, ANDROID_PERMISSION_NFC, null);
 		}
 	}
 
@@ -129,7 +124,7 @@ public class ExternalNfcReaderCallbackSupport {
 
 			recieveReaderBroadcasts = false;
 
-			activity.unregisterReceiver(readerReceiver);
+			context.unregisterReceiver(readerReceiver);
 		}
 	}
 

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcServiceAdapter.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcServiceAdapter.java
@@ -14,8 +14,8 @@ public class ExternalNfcServiceAdapter {
 	protected final Class<? extends Service> serviceClass;
 	protected final boolean foreground;
 
-	public ExternalNfcServiceAdapter(Context activity, Class<? extends Service> serviceClass, boolean foreground) {
-		this.context = activity;
+	public ExternalNfcServiceAdapter(Context context, Class<? extends Service> serviceClass, boolean foreground) {
+		this.context = context;
 		this.serviceClass = serviceClass;
 		this.foreground = foreground;
 	}

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcTagCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcTagCallbackSupport.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.nfc.NfcAdapter;
-import android.util.Log;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,7 +21,7 @@ public class ExternalNfcTagCallbackSupport {
 	public static final String ANDROID_PERMISSION_NFC = "android.permission.NFC";
 
 	protected final ExternalNfcTagCallback callback;
-	protected final Activity activity;
+	protected final Context context;
 
 	private boolean recieveTagBroadcasts = false;
 
@@ -48,9 +47,9 @@ public class ExternalNfcTagCallbackSupport {
 		}
 	};
 
-	public ExternalNfcTagCallbackSupport(ExternalNfcTagCallback callback, Activity activity, Executor executor) {
+	public ExternalNfcTagCallbackSupport(ExternalNfcTagCallback callback, Context context, Executor executor) {
 		this.callback = callback;
-		this.activity = activity;
+		this.context = context;
 		this.executor = executor;
 	}
 
@@ -92,7 +91,7 @@ public class ExternalNfcTagCallbackSupport {
 			IntentFilter filter = new IntentFilter();
 			filter.addAction(ExternalNfcTagCallback.ACTION_TAG_DISCOVERED);
 
-			activity.registerReceiver(tagReceiver, filter, ANDROID_PERMISSION_NFC, null);
+			context.registerReceiver(tagReceiver, filter, ANDROID_PERMISSION_NFC, null);
 		}
 	}
 
@@ -102,7 +101,7 @@ public class ExternalNfcTagCallbackSupport {
 
 			recieveTagBroadcasts = false;
 
-			activity.unregisterReceiver(tagReceiver);
+			context.unregisterReceiver(tagReceiver);
 		}
 	}
 


### PR DESCRIPTION
Dette gjør det enklere for oss å sette opp callbacks for lesere og services uten å måtte ha tilgang til nåværende activity. Krever ingen endringer for brukere, men gir mer fleksibilitet. 

Testet med ACR1252U og intern NFC-leser.