### PR TITLE
Update targetsdk to 34

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,12 +156,12 @@ configure(libraryProjects()) {
     apply plugin: 'com.android.library'
 
     android {
-        compileSdkVersion 31
+        compileSdkVersion 34
         testOptions.unitTests.includeAndroidResources = true
 
         defaultConfig {
             // set minSdkVersion per subproject
-            targetSdkVersion 31
+            targetSdkVersion 34
             // versions are copied here from the properties to improve build time. See the version.gradle script.
             versionCode Integer.parseInt(project.findProperty('versionCode'))
             versionName project.findProperty('version')

--- a/examples/nfc-reader-app/build.gradle
+++ b/examples/nfc-reader-app/build.gradle
@@ -4,12 +4,12 @@ plugins {
 
 android {
     namespace 'no.entur.abt.nfc.example'
-    compileSdk 32
+    compileSdk 34
 
     defaultConfig {
         applicationId "no.entur.abt.nfc.example"
         minSdk 27
-        targetSdk 32
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 

--- a/examples/nfc-reader-app/src/main/java/no/entur/abt/nfc/example/MainActivity.java
+++ b/examples/nfc-reader-app/src/main/java/no/entur/abt/nfc/example/MainActivity.java
@@ -16,7 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
-import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 
@@ -31,6 +30,7 @@ import no.entur.android.nfc.external.ExternalNfcTagLostCallback;
 import no.entur.android.nfc.external.ExternalNfcTagLostCallbackSupport;
 import no.entur.android.nfc.external.acs.reader.AcrReader;
 import no.entur.android.nfc.util.ByteArrayHexStringConverter;
+import no.entur.abt.nfc.example.utils.ParcelableExtraUtils;
 import no.entur.android.nfc.wrapper.Tag;
 import no.entur.android.nfc.wrapper.tech.MifareUltralight;
 import no.entur.android.nfc.wrapper.tech.NfcA;
@@ -135,7 +135,7 @@ public class MainActivity extends AppCompatActivity implements ExternalNfcTagCal
     @Override
     public void onExternalNfcReaderOpened(Intent intent) {
         if (intent.hasExtra(ExternalNfcReaderCallback.EXTRA_READER_CONTROL)) {
-            AcrReader reader = (AcrReader) intent.getParcelableExtra(ExternalNfcReaderCallback.EXTRA_READER_CONTROL);
+            AcrReader reader = ParcelableExtraUtils.getParcelableExtra(intent, ExternalNfcReaderCallback.EXTRA_READER_CONTROL, AcrReader.class);
 
             LOGGER.info("Got reader type " + reader.getClass().getName() + " in activity");
         }

--- a/examples/nfc-reader-app/src/main/java/no/entur/abt/nfc/example/utils/ParcelableExtraUtils.java
+++ b/examples/nfc-reader-app/src/main/java/no/entur/abt/nfc/example/utils/ParcelableExtraUtils.java
@@ -1,0 +1,20 @@
+package no.entur.abt.nfc.example.utils;
+
+import android.content.Intent;
+import android.os.Build;
+import android.os.Parcelable;
+
+public class ParcelableExtraUtils {
+    private ParcelableExtraUtils() {
+
+    }
+
+    public static <T extends Parcelable> T getParcelableExtra(Intent intent, String name, Class<T> parcelableClass) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                return intent.getParcelableExtra(name, parcelableClass);
+            } else {
+                return intent.getParcelableExtra(name);
+            }
+    }
+
+}

--- a/nfc/core/src/main/java/no/entur/android/nfc/util/RegisterReceiverUtils.java
+++ b/nfc/core/src/main/java/no/entur/android/nfc/util/RegisterReceiverUtils.java
@@ -1,0 +1,33 @@
+package no.entur.android.nfc.util;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.IntentFilter;
+import android.os.Build;
+import android.os.Handler;
+
+public class RegisterReceiverUtils {
+
+    private RegisterReceiverUtils() {
+    }
+
+    public static void registerReceiver(Context context, BroadcastReceiver receiver, IntentFilter filter, String broadcastPermission, Handler scheduler, int flags) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(receiver, filter, broadcastPermission, scheduler, flags);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.registerReceiver(receiver, filter, broadcastPermission, scheduler, flags);
+        } else {
+            context.registerReceiver(receiver, filter, broadcastPermission, scheduler);
+        }
+    }
+
+    public static void registerReceiver(Context context, BroadcastReceiver receiver, IntentFilter filter, int flags) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.registerReceiver(receiver, filter, flags);
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.registerReceiver(receiver, filter, flags);
+        } else {
+            context.registerReceiver(receiver, filter);
+        }
+    }
+}

--- a/nfc/core/src/main/java/no/entur/android/nfc/util/RegisterReceiverUtils.java
+++ b/nfc/core/src/main/java/no/entur/android/nfc/util/RegisterReceiverUtils.java
@@ -6,26 +6,24 @@ import android.content.IntentFilter;
 import android.os.Build;
 import android.os.Handler;
 
+import androidx.core.content.ContextCompat;
+
 public class RegisterReceiverUtils {
 
     private RegisterReceiverUtils() {
     }
 
-    public static void registerReceiver(Context context, BroadcastReceiver receiver, IntentFilter filter, String broadcastPermission, Handler scheduler, int flags) {
+    public static void registerReceiverNotExported(Context context, BroadcastReceiver receiver, IntentFilter filter, String broadcastPermission, Handler scheduler) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            context.registerReceiver(receiver, filter, broadcastPermission, scheduler, flags);
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            context.registerReceiver(receiver, filter, broadcastPermission, scheduler, flags);
+            context.registerReceiver(receiver, filter, broadcastPermission, scheduler, Context.RECEIVER_NOT_EXPORTED);
         } else {
             context.registerReceiver(receiver, filter, broadcastPermission, scheduler);
         }
     }
 
-    public static void registerReceiver(Context context, BroadcastReceiver receiver, IntentFilter filter, int flags) {
+    public static void registerReceiverNotExported(Context context, BroadcastReceiver receiver, IntentFilter filter) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            context.registerReceiver(receiver, filter, flags);
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            context.registerReceiver(receiver, filter, flags);
+            context.registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED);
         } else {
             context.registerReceiver(receiver, filter);
         }

--- a/nfc/core/src/main/java/no/entur/android/nfc/util/RegisterReceiverUtils.java
+++ b/nfc/core/src/main/java/no/entur/android/nfc/util/RegisterReceiverUtils.java
@@ -6,8 +6,6 @@ import android.content.IntentFilter;
 import android.os.Build;
 import android.os.Handler;
 
-import androidx.core.content.ContextCompat;
-
 public class RegisterReceiverUtils {
 
     private RegisterReceiverUtils() {

--- a/nfc/external-minova/build.gradle
+++ b/nfc/external-minova/build.gradle
@@ -3,11 +3,11 @@ plugins {
 }
 
 android {
-    compileSdk 31
+    compileSdk 34
 
     defaultConfig {
         minSdk 23
-        targetSdk 31
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcIntentCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcIntentCallbackSupport.java
@@ -7,12 +7,16 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.util.Log;
 
+import androidx.core.content.ContextCompat;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executor;
+
+import no.entur.android.nfc.util.RegisterReceiverUtils;
 
 public class ExternalNfcIntentCallbackSupport {
 
@@ -99,8 +103,14 @@ public class ExternalNfcIntentCallbackSupport {
 			for(String action : actions) {
 				filter.addAction(action);
 			}
-
-			context.registerReceiver(intentReceiver, filter, ANDROID_PERMISSION_NFC, null);
+			RegisterReceiverUtils.registerReceiver(
+					context,
+					intentReceiver,
+					filter,
+					ANDROID_PERMISSION_NFC,
+					null,
+					ContextCompat.RECEIVER_NOT_EXPORTED
+			);
 		}
 	}
 

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcIntentCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcIntentCallbackSupport.java
@@ -7,8 +7,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.util.Log;
 
-import androidx.core.content.ContextCompat;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcIntentCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcIntentCallbackSupport.java
@@ -103,13 +103,12 @@ public class ExternalNfcIntentCallbackSupport {
 			for(String action : actions) {
 				filter.addAction(action);
 			}
-			RegisterReceiverUtils.registerReceiver(
+			RegisterReceiverUtils.registerReceiverNotExported(
 					context,
 					intentReceiver,
 					filter,
 					ANDROID_PERMISSION_NFC,
-					null,
-					ContextCompat.RECEIVER_NOT_EXPORTED
+					null
 			);
 		}
 	}

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcReaderCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcReaderCallbackSupport.java
@@ -117,13 +117,12 @@ public class ExternalNfcReaderCallbackSupport {
 			IntentFilter filter = new IntentFilter();
 			filter.addAction(ExternalNfcReaderCallback.ACTION_READER_OPENED);
 			filter.addAction(ExternalNfcReaderCallback.ACTION_READER_CLOSED);
-			RegisterReceiverUtils.registerReceiver(
+			RegisterReceiverUtils.registerReceiverNotExported(
 					context,
 					readerReceiver,
 					filter,
 					ANDROID_PERMISSION_NFC,
-					null,
-					ContextCompat.RECEIVER_NOT_EXPORTED);
+					null);
 		}
 	}
 

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcReaderCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcReaderCallbackSupport.java
@@ -5,8 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 
-import androidx.core.content.ContextCompat;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcReaderCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcReaderCallbackSupport.java
@@ -5,10 +5,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 
+import androidx.core.content.ContextCompat;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Executor;
+
+import no.entur.android.nfc.util.RegisterReceiverUtils;
 
 public class ExternalNfcReaderCallbackSupport {
 
@@ -113,8 +117,13 @@ public class ExternalNfcReaderCallbackSupport {
 			IntentFilter filter = new IntentFilter();
 			filter.addAction(ExternalNfcReaderCallback.ACTION_READER_OPENED);
 			filter.addAction(ExternalNfcReaderCallback.ACTION_READER_CLOSED);
-
-			context.registerReceiver(readerReceiver, filter, ANDROID_PERMISSION_NFC, null);
+			RegisterReceiverUtils.registerReceiver(
+					context,
+					readerReceiver,
+					filter,
+					ANDROID_PERMISSION_NFC,
+					null,
+					ContextCompat.RECEIVER_NOT_EXPORTED);
 		}
 	}
 

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcServiceCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcServiceCallbackSupport.java
@@ -87,13 +87,12 @@ public class ExternalNfcServiceCallbackSupport {
 			IntentFilter filter = new IntentFilter();
 			filter.addAction(ExternalNfcServiceCallback.ACTION_SERVICE_STARTED);
 			filter.addAction(ExternalNfcServiceCallback.ACTION_SERVICE_STOPPED);
-			RegisterReceiverUtils.registerReceiver(
+			RegisterReceiverUtils.registerReceiverNotExported(
 					context,
 					serviceReceiver,
 					filter,
 					"android.permission.NFC",
-					null,
-					ContextCompat.RECEIVER_NOT_EXPORTED
+					null
 			);
 		}
 	}

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcServiceCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcServiceCallbackSupport.java
@@ -6,8 +6,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.util.Log;
 
-import androidx.core.content.ContextCompat;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcServiceCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcServiceCallbackSupport.java
@@ -6,10 +6,14 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.util.Log;
 
+import androidx.core.content.ContextCompat;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Executor;
+
+import no.entur.android.nfc.util.RegisterReceiverUtils;
 
 public class ExternalNfcServiceCallbackSupport {
 
@@ -83,8 +87,14 @@ public class ExternalNfcServiceCallbackSupport {
 			IntentFilter filter = new IntentFilter();
 			filter.addAction(ExternalNfcServiceCallback.ACTION_SERVICE_STARTED);
 			filter.addAction(ExternalNfcServiceCallback.ACTION_SERVICE_STOPPED);
-
-			context.registerReceiver(serviceReceiver, filter, "android.permission.NFC", null);
+			RegisterReceiverUtils.registerReceiver(
+					context,
+					serviceReceiver,
+					filter,
+					"android.permission.NFC",
+					null,
+					ContextCompat.RECEIVER_NOT_EXPORTED
+			);
 		}
 	}
 

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcTagCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcTagCallbackSupport.java
@@ -93,13 +93,12 @@ public class ExternalNfcTagCallbackSupport {
 			// register receiver
 			IntentFilter filter = new IntentFilter();
 			filter.addAction(ExternalNfcTagCallback.ACTION_TAG_DISCOVERED);
-			RegisterReceiverUtils.registerReceiver(
+			RegisterReceiverUtils.registerReceiverNotExported(
 					context,
 					tagReceiver,
 					filter,
 					ANDROID_PERMISSION_NFC,
-					null,
-					ContextCompat.RECEIVER_NOT_EXPORTED
+					null
 			);
 		}
 	}

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcTagCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcTagCallbackSupport.java
@@ -7,11 +7,14 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.nfc.NfcAdapter;
 
+import androidx.core.content.ContextCompat;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.Executor;
 
+import no.entur.android.nfc.util.RegisterReceiverUtils;
 import no.entur.android.nfc.wrapper.Tag;
 
 public class ExternalNfcTagCallbackSupport {
@@ -90,8 +93,14 @@ public class ExternalNfcTagCallbackSupport {
 			// register receiver
 			IntentFilter filter = new IntentFilter();
 			filter.addAction(ExternalNfcTagCallback.ACTION_TAG_DISCOVERED);
-
-			context.registerReceiver(tagReceiver, filter, ANDROID_PERMISSION_NFC, null);
+			RegisterReceiverUtils.registerReceiver(
+					context,
+					tagReceiver,
+					filter,
+					ANDROID_PERMISSION_NFC,
+					null,
+					ContextCompat.RECEIVER_NOT_EXPORTED
+			);
 		}
 	}
 

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcTagCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcTagCallbackSupport.java
@@ -7,8 +7,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.nfc.NfcAdapter;
 
-import androidx.core.content.ContextCompat;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcTagLostCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcTagLostCallbackSupport.java
@@ -9,8 +9,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.util.Log;
 
-import androidx.core.content.ContextCompat;
-
 import java.util.concurrent.Executor;
 
 import no.entur.android.nfc.util.RegisterReceiverUtils;

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcTagLostCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcTagLostCallbackSupport.java
@@ -1,5 +1,7 @@
 package no.entur.android.nfc.external;
 
+import static android.content.Context.RECEIVER_NOT_EXPORTED;
+
 import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -84,13 +86,12 @@ public class ExternalNfcTagLostCallbackSupport {
 			// register receiver
 			IntentFilter filter = new IntentFilter();
 			filter.addAction(ExternalNfcTagCallback.ACTION_TAG_LEFT_FIELD);
-			RegisterReceiverUtils.registerReceiver(
+			RegisterReceiverUtils.registerReceiverNotExported(
 					activity,
 					tagReceiver,
 					filter,
 					ANDROID_PERMISSION_NFC,
-					null,
-					ContextCompat.RECEIVER_NOT_EXPORTED
+					null
 			);
 		}
 	}

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcTagLostCallbackSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/ExternalNfcTagLostCallbackSupport.java
@@ -7,7 +7,11 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.util.Log;
 
+import androidx.core.content.ContextCompat;
+
 import java.util.concurrent.Executor;
+
+import no.entur.android.nfc.util.RegisterReceiverUtils;
 
 public class ExternalNfcTagLostCallbackSupport {
 
@@ -80,8 +84,14 @@ public class ExternalNfcTagLostCallbackSupport {
 			// register receiver
 			IntentFilter filter = new IntentFilter();
 			filter.addAction(ExternalNfcTagCallback.ACTION_TAG_LEFT_FIELD);
-
-			activity.registerReceiver(tagReceiver, filter, ANDROID_PERMISSION_NFC, null);
+			RegisterReceiverUtils.registerReceiver(
+					activity,
+					tagReceiver,
+					filter,
+					ANDROID_PERMISSION_NFC,
+					null,
+					ContextCompat.RECEIVER_NOT_EXPORTED
+			);
 		}
 	}
 

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/service/ExternalNfcReaderStatusSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/service/ExternalNfcReaderStatusSupport.java
@@ -65,13 +65,12 @@ public class ExternalNfcReaderStatusSupport {
 				// register receiver
 				IntentFilter filter = new IntentFilter();
 				filter.addAction(ExternalNfcReaderCallback.ACTION_READER_STATUS);
-				RegisterReceiverUtils.registerReceiver(
+				RegisterReceiverUtils.registerReceiverNotExported(
 						context,
 						statusReceiver,
 						filter,
 						"android.permission.NFC",
-						null,
-						ContextCompat.RECEIVER_NOT_EXPORTED
+						null
 				);
 			}
 		}

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/service/ExternalNfcReaderStatusSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/service/ExternalNfcReaderStatusSupport.java
@@ -7,10 +7,13 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.util.Log;
 
+import androidx.core.content.ContextCompat;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.entur.android.nfc.external.ExternalNfcReaderCallback;
+import no.entur.android.nfc.util.RegisterReceiverUtils;
 
 /**
  *
@@ -62,8 +65,14 @@ public class ExternalNfcReaderStatusSupport {
 				// register receiver
 				IntentFilter filter = new IntentFilter();
 				filter.addAction(ExternalNfcReaderCallback.ACTION_READER_STATUS);
-
-				context.registerReceiver(statusReceiver, filter, "android.permission.NFC", null);
+				RegisterReceiverUtils.registerReceiver(
+						context,
+						statusReceiver,
+						filter,
+						"android.permission.NFC",
+						null,
+						ContextCompat.RECEIVER_NOT_EXPORTED
+				);
 			}
 		}
 	}

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/service/ExternalNfcReaderStatusSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/service/ExternalNfcReaderStatusSupport.java
@@ -7,8 +7,6 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.util.Log;
 
-import androidx.core.content.ContextCompat;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/service/ExternalUsbNfcServiceSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/service/ExternalUsbNfcServiceSupport.java
@@ -379,11 +379,10 @@ public class ExternalUsbNfcServiceSupport {
 				// register receiver
 				IntentFilter filter = new IntentFilter();
 				filter.addAction(ACTION_USB_PERMISSION);
-				RegisterReceiverUtils.registerReceiver(
+				RegisterReceiverUtils.registerReceiverNotExported(
 						service,
 						usbDevicePermissionReceiver,
-						filter,
-						ContextCompat.RECEIVER_NOT_EXPORTED
+						filter
 				);
 				if (!delay) {
 					readerScanner.resume();
@@ -473,7 +472,7 @@ public class ExternalUsbNfcServiceSupport {
 				// register receiver
 				IntentFilter filter = new IntentFilter();
 				filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
-				RegisterReceiverUtils.registerReceiver(service, usbDeviceDetachedReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
+				RegisterReceiverUtils.registerReceiverNotExported(service, usbDeviceDetachedReceiver, filter);
 			}
 		}
 	}

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/service/ExternalUsbNfcServiceSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/service/ExternalUsbNfcServiceSupport.java
@@ -4,6 +4,7 @@ import android.app.PendingIntent;
 import android.app.Service;
 import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.hardware.usb.UsbDevice;
@@ -14,6 +15,8 @@ import android.os.Handler;
 import android.os.Message;
 import android.util.Log;
 
+import androidx.core.content.ContextCompat;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,6 +26,7 @@ import java.util.Set;
 
 import no.entur.android.nfc.external.ExternalNfcReaderCallback;
 import no.entur.android.nfc.external.service.tag.INFcTagBinder;
+import no.entur.android.nfc.util.RegisterReceiverUtils;
 
 /**
  *
@@ -302,7 +306,7 @@ public class ExternalUsbNfcServiceSupport {
 		int flag = 0;
 
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-			flag = PendingIntent.FLAG_MUTABLE;
+			flag = PendingIntent.FLAG_IMMUTABLE;
 		}
 
 		// Register receiver for USB permission
@@ -375,8 +379,12 @@ public class ExternalUsbNfcServiceSupport {
 				// register receiver
 				IntentFilter filter = new IntentFilter();
 				filter.addAction(ACTION_USB_PERMISSION);
-				service.registerReceiver(usbDevicePermissionReceiver, filter);
-
+				RegisterReceiverUtils.registerReceiver(
+						service,
+						usbDevicePermissionReceiver,
+						filter,
+						ContextCompat.RECEIVER_NOT_EXPORTED
+				);
 				if (!delay) {
 					readerScanner.resume();
 				} else {
@@ -465,7 +473,7 @@ public class ExternalUsbNfcServiceSupport {
 				// register receiver
 				IntentFilter filter = new IntentFilter();
 				filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
-				service.registerReceiver(usbDeviceDetachedReceiver, filter);
+				RegisterReceiverUtils.registerReceiver(service, usbDeviceDetachedReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
 			}
 		}
 	}

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/service/ExternalUsbNfcServiceSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/service/ExternalUsbNfcServiceSupport.java
@@ -15,8 +15,6 @@ import android.os.Handler;
 import android.os.Message;
 import android.util.Log;
 
-import androidx.core.content.ContextCompat;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
RECEIVER_NOT_EXPORTED or RECEIVER_EXPORTED has to be set when registering receivers in Android 34. Not doing so will crash the application. 

It's my understanding that RECEIVER_NOT_EXPORTED is the better option.

From the docs: 
> Runtime-registered broadcasts receivers must specify export behavior
> Apps and services that target Android 14 (API level 34) or higher and use [context-registered receivers](https://developer.android.com/guide/components/broadcasts#context-registered-receivers) are required to specify a flag to indicate whether or not the receiver should be exported to all other apps on the device: either RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED, respectively. This requirement helps protect apps from security vulnerabilities by leveraging the [features for these receivers introduced in Android 13](https://developer.android.com/about/versions/13/features#runtime-receivers).
Exception for receivers that receive only system broadcasts
If your app is registering a receiver only for [system broadcasts](https://developer.android.com/guide/components/broadcasts#system-broadcasts) through Context#registerReceiver methods, such as [Context#registerReceiver()](https://developer.android.com/reference/android/content/Context#registerReceiver(android.content.BroadcastReceiver,%20android.content.IntentFilter)), then it shouldn't specify a flag when registering the receiver.

From implementation docs:
> Choose whether the broadcast receiver should be exported and visible to other apps on the device. If this receiver is listening for broadcasts sent from the system or from other apps—even other apps that you own—use the RECEIVER_EXPORTED flag. If instead this receiver is listening only for broadcasts sent by your app, use the RECEIVER_NOT_EXPORTED flag.

Old versions of Android should run the same as before.