### PR TITLE
Return tag lost via better exception handling for transceive

### DIFF
--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/reader/AcsTransceiveResultExceptionMapper.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/reader/AcsTransceiveResultExceptionMapper.java
@@ -1,0 +1,16 @@
+package no.entur.android.nfc.external.acs.reader;
+
+import com.acs.smartcard.UnresponsiveCardException;
+
+import no.entur.android.nfc.external.tag.TransceiveResultExceptionMapper;
+import no.entur.android.nfc.wrapper.TransceiveResult;
+
+public class AcsTransceiveResultExceptionMapper implements TransceiveResultExceptionMapper {
+    @Override
+    public TransceiveResult mapException(Exception e) {
+        if(e instanceof UnresponsiveCardException) {
+            return new TransceiveResult(TransceiveResult.RESULT_TAGLOST, null);
+        }
+        return new TransceiveResult(TransceiveResult.RESULT_FAILURE, null);
+    }
+}

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/reader/PassthroughCommandException.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/reader/PassthroughCommandException.java
@@ -20,6 +20,9 @@ public class PassthroughCommandException extends RuntimeException {
 		super(throwable);
 
 		this.error = error;
+	}
 
+	public int getError() {
+		return error;
 	}
 }

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/reader/command/ACSIsoDepWrapper.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/reader/command/ACSIsoDepWrapper.java
@@ -21,12 +21,8 @@ public class ACSIsoDepWrapper extends AbstractReaderIsoDepWrapper {
 		// Log.d(TAG, "Transceive request " + ACRCommands.toHexString(data));
 
 		byte[] buffer = new byte[2048];
-		int read;
-		try {
-			read = isoDep.transmit(slotNum, data, data.length, buffer, buffer.length);
-		} catch (ReaderException e) {
-			throw new ReaderException(e);
-		}
+
+		int read = isoDep.transmit(slotNum, data, data.length, buffer, buffer.length);
 
 		byte[] response = new byte[read];
 		System.arraycopy(buffer, 0, response, 0, read);

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/service/AbstractAcsUsbService.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/service/AbstractAcsUsbService.java
@@ -10,6 +10,7 @@ import com.acs.smartcard.Reader;
 import com.acs.smartcard.ReaderException;
 import com.acs.smartcard.RemovedCardException;
 
+import no.entur.android.nfc.external.acs.reader.AcsTransceiveResultExceptionMapper;
 import no.entur.android.nfc.external.acs.tag.DefaultTagTypeDetector;
 import org.nfctools.api.TagType;
 import no.entur.android.nfc.external.acs.tag.TagTypeDetector;

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/service/AcsUsbService.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/service/AcsUsbService.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import no.entur.android.nfc.external.ExternalNfcReaderCallback;
+import no.entur.android.nfc.external.acs.reader.AcsTransceiveResultExceptionMapper;
 import no.entur.android.nfc.external.acs.reader.command.ACSIsoDepWrapper;
 import no.entur.android.nfc.external.acs.tag.MifareUltralightTagServiceSupport;
 import no.entur.android.nfc.external.acs.tag.TagUtility;
@@ -34,8 +35,10 @@ public class AcsUsbService extends AbstractAcsUsbService {
 	public void onCreate() {
 		super.onCreate();
 
-		this.isoDepTagServiceSupport = new IsoDepTagServiceSupport(this, binder, store);
-		this.mifareUltralightTagServiceSupport = new MifareUltralightTagServiceSupport(this, binder, store, false);
+		AcsTransceiveResultExceptionMapper mapper = new AcsTransceiveResultExceptionMapper();
+
+		this.isoDepTagServiceSupport = new IsoDepTagServiceSupport(this, binder, store, mapper);
+		this.mifareUltralightTagServiceSupport = new MifareUltralightTagServiceSupport(this, binder, store, false, mapper);
 	}
 
 	@Override

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/AbstractMifareUltralightTagServiceSupport.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/AbstractMifareUltralightTagServiceSupport.java
@@ -28,6 +28,7 @@ import no.entur.android.nfc.external.service.tag.TagProxyStore;
 import no.entur.android.nfc.external.service.tag.TagTechnology;
 import no.entur.android.nfc.external.tag.AbstractTagServiceSupport;
 import no.entur.android.nfc.external.tag.TechnologyType;
+import no.entur.android.nfc.external.tag.TransceiveResultExceptionMapper;
 import no.entur.android.nfc.wrapper.INfcTag;
 
 public abstract class AbstractMifareUltralightTagServiceSupport extends AbstractTagServiceSupport {
@@ -78,7 +79,7 @@ public abstract class AbstractMifareUltralightTagServiceSupport extends Abstract
         }
     }
 
-    protected boolean isLocked(MfUlReaderWriter readerWriter, MemoryLayout memoryLayout) throws IOException, ReaderException {
+    protected boolean isLocked(MfUlReaderWriter readerWriter, MemoryLayout memoryLayout) throws Exception {
         for (LockPage lockPage : memoryLayout.getLockPages()) {
             MfBlock[] block = readerWriter.readBlock(lockPage.getPage(), 1);
             for (int lockByte : lockPage.getLockBytes()) {

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/MifareUltralightTagServiceSupport.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/MifareUltralightTagServiceSupport.java
@@ -32,6 +32,7 @@ import no.entur.android.nfc.external.service.tag.TagProxyStore;
 import no.entur.android.nfc.external.service.tag.TagTechnology;
 import no.entur.android.nfc.external.tag.AbstractTagServiceSupport;
 import no.entur.android.nfc.external.tag.TechnologyType;
+import no.entur.android.nfc.external.tag.TransceiveResultExceptionMapper;
 import no.entur.android.nfc.wrapper.INfcTag;
 
 public class MifareUltralightTagServiceSupport extends AbstractMifareUltralightTagServiceSupport {
@@ -40,8 +41,12 @@ public class MifareUltralightTagServiceSupport extends AbstractMifareUltralightT
 
     protected MifareUltralightTagFactory mifareUltralightTagFactory = new MifareUltralightTagFactory();
 
-    public MifareUltralightTagServiceSupport(Context context, INfcTag tagService, TagProxyStore store, boolean ntag21xUltralights) {
+    protected TransceiveResultExceptionMapper exceptionMapper;
+
+    public MifareUltralightTagServiceSupport(Context context, INfcTag tagService, TagProxyStore store, boolean ntag21xUltralights, TransceiveResultExceptionMapper exceptionMapper) {
         super(context, tagService, store, ntag21xUltralights);
+
+        this.exceptionMapper = exceptionMapper;
     }
 
     @SuppressWarnings("java:S3776")
@@ -152,11 +157,11 @@ public class MifareUltralightTagServiceSupport extends AbstractMifareUltralightT
             }
 
             if (canReadBlocks) {
-                technologies.add(new MifareUltralightAdapter(readerWriter));
+                technologies.add(new MifareUltralightAdapter(readerWriter, exceptionMapper));
             }
 
             if (TechnologyType.isNFCA(atr)) {
-                technologies.add(new PN532NfcAAdapter(wrapper, false));
+                technologies.add(new PN532NfcAAdapter(wrapper, false, exceptionMapper));
                 // technologies.add(new NfcAAdapter(slotNumber, reader, false));
             }
 

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/PN532DefaultTechnology.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/PN532DefaultTechnology.java
@@ -3,6 +3,8 @@ package no.entur.android.nfc.external.acs.tag;
 import android.os.RemoteException;
 import android.util.Log;
 
+import com.acs.smartcard.UnresponsiveCardException;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10,6 +12,7 @@ import no.entur.android.nfc.external.acs.reader.command.ACSIsoDepWrapper;
 import no.entur.android.nfc.external.service.tag.CommandTechnology;
 import no.entur.android.nfc.external.tag.AbstractReaderIsoDepWrapper;
 import no.entur.android.nfc.external.tag.DefaultTechnology;
+import no.entur.android.nfc.external.tag.TransceiveResultExceptionMapper;
 import no.entur.android.nfc.util.ByteArrayHexStringConverter;
 import no.entur.android.nfc.wrapper.TransceiveResult;
 
@@ -20,11 +23,14 @@ public class PN532DefaultTechnology extends DefaultTechnology implements Command
 	protected AbstractReaderIsoDepWrapper reader;
 	private boolean print;
 
-	public PN532DefaultTechnology(int tagTechnology, AbstractReaderIsoDepWrapper reader, boolean print) {
+	private TransceiveResultExceptionMapper exceptionMapper;
+
+	public PN532DefaultTechnology(int tagTechnology, AbstractReaderIsoDepWrapper reader, boolean print, TransceiveResultExceptionMapper exceptionMapper) {
 		super(tagTechnology);
 
 		this.reader = reader;
 		this.print = print;
+		this.exceptionMapper = exceptionMapper;
 	}
 
 	@Override
@@ -56,7 +62,7 @@ public class PN532DefaultTechnology extends DefaultTechnology implements Command
 		} catch (Exception e) {
 			LOGGER.debug("Problem sending command", e);
 
-			return new TransceiveResult(TransceiveResult.RESULT_FAILURE, null);
+			return exceptionMapper.mapException(e);
 		}
 	}
 }

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/PN532NfcAAdapter.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/tag/PN532NfcAAdapter.java
@@ -2,14 +2,15 @@ package no.entur.android.nfc.external.acs.tag;
 
 import no.entur.android.nfc.external.acs.reader.command.ACSIsoDepWrapper;
 import no.entur.android.nfc.external.tag.AbstractReaderIsoDepWrapper;
+import no.entur.android.nfc.external.tag.TransceiveResultExceptionMapper;
 import no.entur.android.nfc.wrapper.tech.TagTechnology;
 
 public class PN532NfcAAdapter extends PN532DefaultTechnology {
 
 	protected static final String TAG = PN532NfcAAdapter.class.getName();
 
-	public PN532NfcAAdapter(AbstractReaderIsoDepWrapper reader, boolean print) {
-		super(TagTechnology.NFC_A, reader, print);
+	public PN532NfcAAdapter(AbstractReaderIsoDepWrapper reader, boolean print, TransceiveResultExceptionMapper exceptionMapper) {
+		super(TagTechnology.NFC_A, reader, print, exceptionMapper);
 	}
 
 	public String toString() {

--- a/nfc/external-acs/src/main/java/org/nfctools/mf/ul/MfUlReaderWriter.java
+++ b/nfc/external-acs/src/main/java/org/nfctools/mf/ul/MfUlReaderWriter.java
@@ -25,15 +25,15 @@ import com.acs.smartcard.ReaderException;
 
 public interface MfUlReaderWriter {
 
-	byte[] transmit(byte[] data) throws ReaderException;
+	byte[] transmit(byte[] data) throws Exception;
 
-	Response transmit(Command command) throws ReaderException;
+	Response transmit(Command command) throws Exception;
 
-	MfBlock[] readBlock(int startPage, int pagesToRead) throws IOException, ReaderException;
+	MfBlock[] readBlock(int startPage, int pagesToRead) throws Exception;
 
-	void writeBlock(int startPage, MfBlock... mfBlock) throws IOException;
+	void writeBlock(int startPage, MfBlock... mfBlock) throws Exception;
 
 	int getMaxPagesPerRead();
 
-	byte[] transmitPassthrough(byte[] data) throws ReaderException;
+	byte[] transmitPassthrough(byte[] data) throws Exception;
 }

--- a/nfc/external-acs/src/main/java/org/nfctools/spi/acs/AcrMfUlNTAGReaderWriter.java
+++ b/nfc/external-acs/src/main/java/org/nfctools/spi/acs/AcrMfUlNTAGReaderWriter.java
@@ -27,11 +27,11 @@ public class AcrMfUlNTAGReaderWriter implements MfUlReaderWriter {
 		this.version = version;
 	}
 
-	public byte[] transmit(byte[] data) throws ReaderException {
+	public byte[] transmit(byte[] data) throws Exception {
 		return tag.transmit(data);
 	}
 
-	public Response transmit(Command command) throws ReaderException {
+	public Response transmit(Command command) throws Exception {
 		return tag.transmit(command);
 	}
 
@@ -62,7 +62,7 @@ public class AcrMfUlNTAGReaderWriter implements MfUlReaderWriter {
 	}
 
 	@Override
-	public void writeBlock(int startPage, MfBlock... mfBlock) throws IOException {
+	public void writeBlock(int startPage, MfBlock... mfBlock) throws Exception {
 		for (int currentBlock = 0; currentBlock < mfBlock.length; currentBlock++) {
 			int blockNumber = startPage + currentBlock;
 
@@ -89,7 +89,7 @@ public class AcrMfUlNTAGReaderWriter implements MfUlReaderWriter {
 	}
 
 	@Override
-	public byte[] transmitPassthrough(byte[] data) {
+	public byte[] transmitPassthrough(byte[] data) throws Exception {
 		return tag.transmitPassthrough(data);
 	}
 

--- a/nfc/external-acs/src/main/java/org/nfctools/spi/acs/AcrMfUlReaderWriter.java
+++ b/nfc/external-acs/src/main/java/org/nfctools/spi/acs/AcrMfUlReaderWriter.java
@@ -35,16 +35,16 @@ public class AcrMfUlReaderWriter implements MfUlReaderWriter {
 		this.tag = tag;
 	}
 
-	public byte[] transmit(byte[] data) throws ReaderException {
+	public byte[] transmit(byte[] data) throws Exception {
 		return tag.transmit(data);
 	}
 
-	public Response transmit(Command command) throws ReaderException {
+	public Response transmit(Command command) throws Exception {
 		return tag.transmit(command);
 	}
 
 	@Override
-	public MfBlock[] readBlock(int startPage, int pagesToRead) throws IOException {
+	public MfBlock[] readBlock(int startPage, int pagesToRead) throws Exception {
 		MfBlock[] returnBlocks = new MfBlock[pagesToRead];
 
 		/*
@@ -83,7 +83,7 @@ public class AcrMfUlReaderWriter implements MfUlReaderWriter {
 	}
 
 	@Override
-	public void writeBlock(int startPage, MfBlock... mfBlock) throws IOException {
+	public void writeBlock(int startPage, MfBlock... mfBlock) throws Exception {
 		for (int currentBlock = 0; currentBlock < mfBlock.length; currentBlock++) {
 			int blockNumber = startPage + currentBlock;
 
@@ -102,7 +102,7 @@ public class AcrMfUlReaderWriter implements MfUlReaderWriter {
 	}
 
 	@Override
-	public byte[] transmitPassthrough(byte[] data) {
+	public byte[] transmitPassthrough(byte[] data) throws Exception {
 		return tag.transmitPassthrough(data);
 	}
 }

--- a/nfc/external-acs/src/main/java/org/nfctools/spi/acs/AcsTag.java
+++ b/nfc/external-acs/src/main/java/org/nfctools/spi/acs/AcsTag.java
@@ -17,6 +17,8 @@ package org.nfctools.spi.acs;
 
 import android.util.Log;
 
+import com.acs.smartcard.ReaderException;
+
 import org.nfctools.NfcException;
 import org.nfctools.api.ApduTag;
 import org.nfctools.api.Tag;
@@ -59,29 +61,25 @@ public class AcsTag extends Tag implements ApduTag {
 	}
 
 	@Override
-	public Response transmit(Command command) {
-		try {
-			CommandAPDU commandAPDU = null;
-			if (command.isDataOnly()) {
-				commandAPDU = new CommandAPDU(0xff, 0, 0, 0, command.getData(), command.getOffset(), command.getLength());
-			} else if (command.hasData()) {
-				commandAPDU = new CommandAPDU(Apdu.CLS_PTS, command.getInstruction(), command.getP1(), command.getP2(), command.getData());
-			} else {
-				commandAPDU = new CommandAPDU(Apdu.CLS_PTS, command.getInstruction(), command.getP1(), command.getP2(), command.getLength());
-			}
-			byte[] out = commandAPDU.getBytes();
-
-			// Log.d(TAG, "Request: " + ByteArrayHexStringConverter.toHexString(out));
-
-			byte[] in = reader.transmit(slot, out);
-
-			// Log.d(TAG, "Response: " + ByteArrayHexStringConverter.toHexString(in));
-
-			ResponseAPDU responseAPDU = new ResponseAPDU(in);
-			return new Response(responseAPDU.getSW1(), responseAPDU.getSW2(), responseAPDU.getData());
-		} catch (Exception e) {
-			throw new NfcException(e);
+	public Response transmit(Command command) throws ReaderException {
+		CommandAPDU commandAPDU = null;
+		if (command.isDataOnly()) {
+			commandAPDU = new CommandAPDU(0xff, 0, 0, 0, command.getData(), command.getOffset(), command.getLength());
+		} else if (command.hasData()) {
+			commandAPDU = new CommandAPDU(Apdu.CLS_PTS, command.getInstruction(), command.getP1(), command.getP2(), command.getData());
+		} else {
+			commandAPDU = new CommandAPDU(Apdu.CLS_PTS, command.getInstruction(), command.getP1(), command.getP2(), command.getLength());
 		}
+		byte[] out = commandAPDU.getBytes();
+
+		// Log.d(TAG, "Request: " + ByteArrayHexStringConverter.toHexString(out));
+
+		byte[] in = reader.transmit(slot, out);
+
+		// Log.d(TAG, "Response: " + ByteArrayHexStringConverter.toHexString(in));
+
+		ResponseAPDU responseAPDU = new ResponseAPDU(in);
+		return new Response(responseAPDU.getSW1(), responseAPDU.getSW2(), responseAPDU.getData());
 	}
 
 	@Override

--- a/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/service/MinovaService.java
+++ b/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/service/MinovaService.java
@@ -32,7 +32,7 @@ public class MinovaService extends AbstractMinovaTcpService {
     public void onCreate() {
         super.onCreate();
 
-        this.isoDepTagServiceSupport = new IsoDepTagServiceSupport(this, binder, store);
+        this.isoDepTagServiceSupport = new IsoDepTagServiceSupport(this, binder, store, new MinovaTransceiveResultExceptionMapper());
     }
 
     @Override

--- a/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/service/MinovaTransceiveResultExceptionMapper.java
+++ b/nfc/external-minova/src/main/java/no/entur/android/nfc/external/minova/service/MinovaTransceiveResultExceptionMapper.java
@@ -1,0 +1,12 @@
+package no.entur.android.nfc.external.minova.service;
+
+import no.entur.android.nfc.external.tag.TransceiveResultExceptionMapper;
+import no.entur.android.nfc.wrapper.TransceiveResult;
+
+public class MinovaTransceiveResultExceptionMapper implements TransceiveResultExceptionMapper {
+
+    @Override
+    public TransceiveResult mapException(Exception e) {
+        return new TransceiveResult(TransceiveResult.RESULT_FAILURE, null);
+    }
+}

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/tag/IsoDepAdapter.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/tag/IsoDepAdapter.java
@@ -17,11 +17,13 @@ public class IsoDepAdapter extends DefaultTechnology implements CommandTechnolog
 
 	private DESFireAdapter adapter;
 	private boolean hostCardEmulation;
+	private TransceiveResultExceptionMapper mapper;
 
-	public IsoDepAdapter(AbstractReaderIsoDepWrapper isoDep, boolean hostCardEmulation) {
+	public IsoDepAdapter(AbstractReaderIsoDepWrapper isoDep, boolean hostCardEmulation, TransceiveResultExceptionMapper mapper) {
 		super(TagTechnology.ISO_DEP);
 		this.adapter = new DESFireAdapter(isoDep, false);
 		this.hostCardEmulation = hostCardEmulation;
+		this.mapper = mapper;
 	}
 
 	public TransceiveResult transceive(byte[] data, boolean raw) throws RemoteException {
@@ -43,7 +45,7 @@ public class IsoDepAdapter extends DefaultTechnology implements CommandTechnolog
 		} catch (Exception e) {
 			LOGGER.debug("Problem sending command", e);
 
-			return new TransceiveResult(TransceiveResult.RESULT_FAILURE, null);
+			return mapper.mapException(e);
 		}
 
 	}

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/tag/IsoDepTagServiceSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/tag/IsoDepTagServiceSupport.java
@@ -20,16 +20,19 @@ public class IsoDepTagServiceSupport extends AbstractTagServiceSupport {
     private static final Logger LOGGER = LoggerFactory.getLogger(IsoDepTagServiceSupport.class);
 
     protected IsoDepTagFactory isoDepTagFactory = new IsoDepTagFactory();
+    protected TransceiveResultExceptionMapper transceiveResultExceptionMapper;
 
-    public IsoDepTagServiceSupport(Context context, INfcTag tagService, TagProxyStore store) {
+    public IsoDepTagServiceSupport(Context context, INfcTag tagService, TagProxyStore store, TransceiveResultExceptionMapper transceiveResultExceptionMapper) {
         super(context, tagService, store);
+
+        this.transceiveResultExceptionMapper = transceiveResultExceptionMapper;
     }
 
     public TagProxy hce(int slotNumber, AbstractReaderIsoDepWrapper wrapper, byte[] uid, byte[] historicalBytes, IntentEnricher extras) {
         try {
             List<TagTechnology> technologies = new ArrayList<>();
-            technologies.add(new NfcAAdapter(wrapper, true));
-            technologies.add(new IsoDepAdapter(wrapper, true));
+            technologies.add(new NfcAAdapter(wrapper, transceiveResultExceptionMapper,true));
+            technologies.add(new IsoDepAdapter(wrapper, true, transceiveResultExceptionMapper));
 
             TagProxy tagProxy = store.add(slotNumber, technologies);
 
@@ -51,8 +54,8 @@ public class IsoDepTagServiceSupport extends AbstractTagServiceSupport {
     public TagProxy card(int slotNumber, AbstractReaderIsoDepWrapper wrapper, byte[] uid, byte[] historicalBytes, IntentEnricher extras) {
         try {
             List<TagTechnology> technologies = new ArrayList<>();
-            technologies.add(new NfcAAdapter(wrapper, false));
-            technologies.add(new IsoDepAdapter(wrapper, false));
+            technologies.add(new NfcAAdapter(wrapper, transceiveResultExceptionMapper, false));
+            technologies.add(new IsoDepAdapter(wrapper, false, transceiveResultExceptionMapper));
 
             TagProxy tagProxy = store.add(slotNumber, technologies);
 

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/tag/NfcAAdapter.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/tag/NfcAAdapter.java
@@ -20,11 +20,13 @@ public class NfcAAdapter extends DefaultTechnology implements CommandTechnology 
 	private static final Logger LOGGER = LoggerFactory.getLogger(NfcAAdapter.class);
 
 	private AbstractReaderIsoDepWrapper wrapper;
+	private TransceiveResultExceptionMapper mapper;
 	private boolean print;
 
-	public NfcAAdapter(AbstractReaderIsoDepWrapper wrapper, boolean print) {
+	public NfcAAdapter(AbstractReaderIsoDepWrapper wrapper, TransceiveResultExceptionMapper mapper, boolean print) {
 		super(TagTechnology.NFC_A);
 		this.wrapper = wrapper;
+		this.mapper = mapper;
 		this.print = print;
 	}
 
@@ -56,7 +58,7 @@ public class NfcAAdapter extends DefaultTechnology implements CommandTechnology 
 		} catch (Exception e) {
 			LOGGER.debug("Problem sending command", e);
 
-			return new TransceiveResult(TransceiveResult.RESULT_FAILURE, null);
+			return mapper.mapException(e);
 		}
 
 	}

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/tag/TransceiveResultExceptionMapper.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/tag/TransceiveResultExceptionMapper.java
@@ -1,0 +1,14 @@
+package no.entur.android.nfc.external.tag;
+
+import no.entur.android.nfc.wrapper.TransceiveResult;
+
+/**
+ *
+ * Exception mapper for more detailed {@linkplain TransceiveResult}.
+ *
+ */
+public interface TransceiveResultExceptionMapper {
+
+    TransceiveResult mapException(Exception e);
+
+}

--- a/nfc/external/src/main/java/org/nfctools/api/ApduTag.java
+++ b/nfc/external/src/main/java/org/nfctools/api/ApduTag.java
@@ -22,10 +22,10 @@ public interface ApduTag {
 
 	TagType getTagType();
 
-	Response transmit(Command command);
+	Response transmit(Command command) throws Exception;
 
-	byte[] transmit(byte[] in);
+	byte[] transmit(byte[] in) throws Exception;;
 
-	byte[] transmitPassthrough(byte[] in);
+	byte[] transmitPassthrough(byte[] in) throws Exception;;
 
 }


### PR DESCRIPTION
Add an exception mapper which maps ACS driver errors like `UnresponsiveCardException` to tag lost. 

Tested using logging and

```
        IsoDep isoDep = IsoDep.get(tag);
        if(isoDep != null) {

            try {
                isoDep.connect();
                while(true) {
                    LOGGER.info("Sending select application");

                    isoDep.transceive(wrapMessage(SELECT_APPLICATION, new byte[]{(byte) 0x00, (byte) 0x80, (byte) 0x57}));
                    Thread.sleep(10);
                }
            } catch (Exception e) {
                LOGGER.info("Problem sending select application", e);
            } finally {
                try {
                    isoDep.close();
                } catch (IOException e) {
                    throw new RuntimeException(e);
                }

            }
        } else {
            LOGGER.info("Sending select application");
        }

```


```
2024-03-18 12:13:27.886 23292-23370 no.entur.a...UsbService no.entur.abt.nfc.example             I  [Thread-4] onTagAbsent
2024-03-18 12:13:27.894 23292-23365 no.entur.a...inActivity no.entur.abt.nfc.example             I  [pool-2-thread-1] Sending select application
2024-03-18 12:13:27.910 23292-23365 no.entur.a...inActivity no.entur.abt.nfc.example             I  [pool-2-thread-1] Problem sending select application
                                                                                                    android.nfc.TagLostException: Tag was lost.
                                                                                                    	at no.entur.android.nfc.wrapper.TransceiveResult.getResponseOrThrow(TransceiveResult.java:49)
                                                                                                    	at no.entur.android.nfc.wrapper.tech.BasicTagTechnologyImpl.transceive(BasicTagTechnologyImpl.java:149)
                                                                                                    	at no.entur.android.nfc.wrapper.tech.IsoDepImpl.transceive(IsoDepImpl.java:166)
                                                                                                    	at no.entur.abt.nfc.example.MainActivity.onExternalTagDiscovered(MainActivity.java:182)
                                                                                                    	at no.entur.android.nfc.external.ExternalNfcTagCallbackSupport$1.lambda$onReceive$0$no-entur-android-nfc-external-ExternalNfcTagCallbackSupport$1(ExternalNfcTagCallbackSupport.java:38)
                                                                                                    	at no.entur.android.nfc.external.ExternalNfcTagCallbackSupport$1$$ExternalSyntheticLambda0.run(Unknown Source:6)
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
                                                                                                    	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
                                                                                                    	at java.lang.Thread.run(Thread.java:1012)
```
