### PR TITLE
Skip unsupported usb devices

### DIFF
--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/service/AcrReaderAdapter.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/service/AcrReaderAdapter.java
@@ -52,6 +52,7 @@ public class AcrReaderAdapter implements ExternalUsbNfcServiceSupport.ReaderAdap
 	protected INFcTagBinder binder;
 	
 	protected WrappedAcrReader reader;
+	private final int acsVendorId = 1839;
 
 	protected Context context;
 
@@ -150,6 +151,8 @@ public class AcrReaderAdapter implements ExternalUsbNfcServiceSupport.ReaderAdap
 
 	@Override
 	public boolean isSupportedDevice(UsbDevice device, UsbManager usbManager) {
+		if (device.getVendorId() != acsVendorId) return false;
+
 		return new ReaderWrapper(usbManager).isSupported(device);
 	}
 

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/service/AcrReaderAdapter.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/service/AcrReaderAdapter.java
@@ -3,7 +3,6 @@ package no.entur.android.nfc.external.acs.service;
 import android.content.Context;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
-import android.util.Log;
 
 import com.acs.smartcard.ReaderException;
 
@@ -147,6 +146,11 @@ public class AcrReaderAdapter implements ExternalUsbNfcServiceSupport.ReaderAdap
 		this.reader = wrappedAcrReader;
 		
 		return wrappedAcrReader;
+	}
+
+	@Override
+	public boolean isSupportedDevice(UsbDevice device, UsbManager usbManager) {
+		return new ReaderWrapper(usbManager).isSupported(device);
 	}
 
 	protected AcrReader createUsbAcrReader(ACRCommands reader) {

--- a/nfc/external/src/main/java/no/entur/android/nfc/external/service/ExternalUsbNfcServiceSupport.java
+++ b/nfc/external/src/main/java/no/entur/android/nfc/external/service/ExternalUsbNfcServiceSupport.java
@@ -4,7 +4,6 @@ import android.app.PendingIntent;
 import android.app.Service;
 import android.content.BroadcastReceiver;
 import android.content.Context;
-import android.content.ContextWrapper;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.hardware.usb.UsbDevice;
@@ -13,7 +12,6 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Message;
-import android.util.Log;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +21,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import no.entur.android.nfc.external.ExternalNfcReaderCallback;
-import no.entur.android.nfc.external.service.tag.INFcTagBinder;
 import no.entur.android.nfc.util.RegisterReceiverUtils;
 
 /**
@@ -43,6 +40,7 @@ public class ExternalUsbNfcServiceSupport {
 
 		T openReader(UsbDevice param);
 
+		boolean isSupportedDevice(UsbDevice device, UsbManager usbManager);
 	}
 
 	private static class Scanner extends Handler {
@@ -320,6 +318,7 @@ public class ExternalUsbNfcServiceSupport {
 
 		for (UsbDevice device : usbManager.getDeviceList().values()) {
 			synchronized (this) {
+				if (!readerAdapter.isSupportedDevice(device, usbManager)) continue;
 				return detectUSBDevice(device);
 			}
 		}


### PR DESCRIPTION
Fixes issue where permission is asked, and OpenReaderTask executed, for unsupported device. That would result in a supported device being skipped depending on its position in the UsbManager device list. 