### PR TITLE
Crash investigation

### DIFF
--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/reader/ReaderWrapper.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/reader/ReaderWrapper.java
@@ -22,10 +22,13 @@ public class ReaderWrapper {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(ReaderWrapper.class);
 
-	private Reader reader;
+	private final Reader reader;
 
-	public ReaderWrapper(UsbManager mManager) {
-		this.reader = new Reader(mManager);
+	public ReaderWrapper(UsbManager manager) {
+		if(manager == null) {
+			throw new IllegalArgumentException("UsbManager must not be null");
+		}
+		this.reader = new Reader(manager);
 	}
 
 	public boolean isSupported(UsbDevice device) {

--- a/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/service/WrappedAcrReader.java
+++ b/nfc/external-acs/src/main/java/no/entur/android/nfc/external/acs/service/WrappedAcrReader.java
@@ -9,6 +9,12 @@ public class WrappedAcrReader {
     private final AcrReader acrReader;
 
     public WrappedAcrReader(ReaderWrapper readerWrapper, AcrReader acrReader) {
+        if(readerWrapper == null) {
+            throw new IllegalArgumentException("ReaderWrapper must not be null");
+        }
+        if(acrReader == null) {
+            throw new IllegalArgumentException("ACR reader must not be null");
+        }
         this.readerWrapper = readerWrapper;
         this.acrReader = acrReader;
     }


### PR DESCRIPTION
> NullPointerException: Attempt to invoke virtual method 'java.lang.String no.entur.android.nfc.external.remote.RemoteCommandReader.getName()' on a null object reference
       at no.entur.android.nfc.external.acs.service.AcrReaderListener.onReaderOpen(AcrReaderListener.java:59)


Plan: Upgrade to latest version. If it happens again, fail fast via illegal argument exception.